### PR TITLE
Add FontsWiki typography resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated collection of awesome web typography articles.
 - [brick.im](https://github.com/alfredxing/brick)
 - [Typebase.css](http://devinhunt.github.io/typebase.css/)
 - [Google WebFonts Helper](https://google-webfonts-helper.herokuapp.com/fonts/aguafina-script?subsets=latin)
+- [FontsWiki - Searchable font catalog with free alternatives and Fonts-in-Use references for designers and developers.](https://fontswiki.com)
 - [Using Custom Fonts in Emails](https://github.com/ladjs/custom-fonts-in-emails)
 - [Typographist — Modular scale calculator API with config validation](https://github.com/typographist)
 - [Font Face Observer is a fast and simple web font loader](https://fontfaceobserver.com/)


### PR DESCRIPTION
Hi, thanks for maintaining this list.

This PR adds FontsWiki, a typography reference resource for finding fonts, free alternatives, and real-world font usage examples across films, TV, games, books, music, logos, and digital products.

Why it fits this list:

- It includes a searchable free-font catalog.
- It has dedicated free-alternative pages for common commercial/system fonts such as Helvetica, Arial, Times New Roman, Georgia, and Calibri.
- It includes a Fonts-in-Use archive with source-backed examples and free substitutes where available.
- It is useful for designers and developers choosing fonts for web, product, branding, and editorial work.

Link: https://fontswiki.com

I kept the entry short and placed it in the Tools section. Happy to adjust wording or placement if you prefer a different category.